### PR TITLE
Fixed font-family issue in .share-tech-mono-regular

### DIFF
--- a/index.css
+++ b/index.css
@@ -8,10 +8,11 @@
   }
 
 .share-tech-mono-regular {
-    font-family: "Mono", serif;
+    font-family: "Share Tech Mono", monospace;
     font-weight: 400;
     font-style: normal;
-  }
+}
+
   
 body {
     font-family: 'Roboto', sans-serif;


### PR DESCRIPTION
 The font was incorrectly set to "Mono", serif; instead of "Share Tech Mono", monospace;, which caused inconsistencies in styling